### PR TITLE
Fix for issue #3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,18 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
             <version>${cxf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.javamail</groupId>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+        </dependency>
+
 
 
         <!-- Guice -->


### PR DESCRIPTION
I encountered the same issue as @emilbokenstrand and @ekorra reported in issue #3.

The issue probably manifests itself on my side due to building Oxalis and Oxalis-AS4 plugin and my custom plugin for themselves, and then injecting the AS4 plugin and my own plugin into oxalis.war using the jar command, causing the geronimo.javamail class being included and loading before javax.mail (or something to that effect).

The fix suggested by @FrodeBjerkholt did indeed work. Modifying the dependencies to exclude geronimo.javamail and include javax.mail instead do fix the problem.

Since oxalis-as2 has a dependency to javax.mail, I suggest specifying this dependency in the AS4-plugin to.