### PR TITLE
Upgraded Oxalis Docker image to 4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN cd $MAVEN_HOME \
  && cp -r target/$(ls target | grep "\-dist$" | head -1) /dist
 
 
-FROM difi/oxalis:4.0.4
+FROM difi/oxalis:4.1.0
 
 COPY --from=mvn /dist /oxalis/ext


### PR DESCRIPTION
Upgrade to go with 5a577215a912eeaac8bbbe1b4ca6efb0956498e5.