### PR TITLE
Upgrade Oxalis Docker image to 4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN cd $MAVEN_HOME \
  && cp -r target/$(ls target | grep "\-dist$" | head -1) /dist
 
 
-FROM difi/oxalis:4.1.0
+FROM difi/oxalis:4.1.1
 
 COPY --from=mvn /dist /oxalis/ext


### PR DESCRIPTION
Please upgrade the Oxalis Docker image to 4.1.1 as it includes the fix to the breaking changes in older versions of Oxalis [#452](https://github.com/difi/oxalis/issues/452)